### PR TITLE
Adding NewsAPI.org wrapper as a 'pkg'.

### DIFF
--- a/blocks/pkg-news-api/index.js
+++ b/blocks/pkg-news-api/index.js
@@ -1,0 +1,36 @@
+const { Block } = require('node-webpipe')
+const NewsAPI = require('newsapi')
+const client = new NewsAPI(process.env.API_KEY_NEWSAPI)
+
+// const { Block, Client, MSG } = require('@webpipes/server')
+new Block()
+  .name("News API's Top Headline's")
+  .description("NewsAPI.org's REST API service (https://newsapi.org)")
+  // @NOTE: Maybe in the future, we are using some kind of standard
+  // (&localized) in cases where we wrap other services. Maybe we can
+  // standardize these boilerplate proxy/wrapper
+  // user messages. NOTICE(`@NOTE/API/1`, locale)
+  .input(
+    'sources',
+    // @TODO: Hack fix for `node-webpipe` server validation didn't like `array`?
+    'object',
+    '@NOTE/API/1: Refer to official API service docs. Defaults to the New York Times.'
+  )
+  .output(
+    'articles',
+    'object',
+    'Top headlines and ledes from requested source(s).'
+  )
+  .handle(({ sources = ['the-new-york-times'] }, cb) => {
+    const articles = client.v2
+      .topHeadlines({
+        sources: sources,
+        language: 'en'
+      })
+      .then(({ articles }) => {
+        cb(null, {
+          articles
+        })
+      })
+  })
+  .listen()

--- a/blocks/pkg-news-api/package-lock.json
+++ b/blocks/pkg-news-api/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "pkg-news-api",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/polyfill": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
+      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
+    "core-js": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+    },
+    "newsapi": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/newsapi/-/newsapi-2.4.0.tgz",
+      "integrity": "sha512-1cupr3Gksz9GiwGLJfCWySoAVY+CPAZ4+3w8wEKFXBuHqUyq4+SqTbCVZ0FNvJ3w2oX2NxeVOiL17Phta+E6gA==",
+      "requires": {
+        "@babel/polyfill": "^7.0.0",
+        "node-fetch": "^2.2.0"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+    }
+  }
+}

--- a/blocks/pkg-news-api/package.json
+++ b/blocks/pkg-news-api/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "pkg-news-api",
+  "dependencies": {
+    "newsapi": "^2.4.0"
+  }
+}


### PR DESCRIPTION
A 'package' is just a naming convention I've been working w/ locally. Basically, a package is a set of closely related services (either thematically or in functionality), and usually sitting side-by-side on the same infra.